### PR TITLE
Set the session ID query param as a partition key

### DIFF
--- a/infrastructure/src/constructs/api-construct.ts
+++ b/infrastructure/src/constructs/api-construct.ts
@@ -570,6 +570,7 @@ export class ApiConstruct extends Construct {
                     {
                       "StreamName": "${props.gameEventsStream.streamName}",
                       "Records": [
+                        #set($sessionId = $input.params().querystring.SessionID)
                         #set($i = 0)
                         #foreach($event in $input.path('$.Events'))
                           #set($data = $input.json("$.Events[$i]"))
@@ -582,7 +583,7 @@ export class ApiConstruct extends Construct {
                           }" )
                           {
                             "Data": "$util.base64Encode($output)",
-                            "PartitionKey": "$event.event_id"
+                            "PartitionKey": "$sessionId"
                           }#if($foreach.hasNext),#end
                           #set($i = $i + 1)
                         #end


### PR DESCRIPTION
Since we don't have an event_id, the request template was having a fit about the partion key missing. We should use the Session ID since we will likely group on this frequently